### PR TITLE
新增自動部署至gh-page 設定環境變數

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Build and Deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run build
+        env:
+          VUE_APP_APP_ID: ${{ secrets.VUE_APP_APP_ID }}
+          VUE_APP_APP_KEY: ${{ secrets.VUE_APP_APP_KEY }}
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: dist

--- a/src/modules.js
+++ b/src/modules.js
@@ -1,8 +1,8 @@
 // API 驗證
 import jsSHA from "jssha/dist/sha1";
 const getAuthHeader = () => {
-  const AppID = "2dfbcb68d0e04fb5bc9d1f59f2e3df35";
-  const AppKey = "HmEvi7uEhV77UNGt-MYo6ETs43E";
+  const AppID = process.env.VUE_APP_APP_ID
+  const AppKey = process.env.VUE_APP_APP_KEY
   const GMTString = new Date().toGMTString();
   const ShaObj = new jsSHA("SHA-1", "TEXT");
   ShaObj.setHMACKey(AppKey, "TEXT");


### PR DESCRIPTION
# 我把你api key的部分刪掉了

## 你要如何前端保存重要key資料

可以先參考 vue cli 官方的[這篇文章](https://cli.vuejs.org/zh/guide/mode-and-env.html#%E7%8E%AF%E5%A2%83%E5%8F%98%E9%87%8F)

## 同意pr後

### 新增本地開發環境變數

新增一個`.env.local`的檔案在根目錄
並在裡面設定兩個環境變數

`VUE_APP_APP_ID={{ app id }}`
`VUE_APP_APP_KEY={{ app key }}`

重新`npm run serve`一次

即可在本地正常開發並且不會將key的部分commit上github

### 設定自動部署環境變數

去你[github](https://github.com/timchen0607/Travel-Guide)點右上角`Setting`
左邊有個`Secrets` 點 `New`

| Name | VUE_APP_APP_ID| VUE_APP_APP_KEY |
|:--------:|:--------:|:--------:|
|   Value   |  {{ app id }}  |  {{ app key }}  |

把你兩個環境變數設定進去
就可以享受github action 的便利
